### PR TITLE
Option to require specific address

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,36 @@ const request: SafeSignerRequest = {
 // Send a message to be signed by the user
 const { data: signedMessage, error } = await signer.signRequest(request);
 ```
-The user is then prompted to sign the message or transaction in their browser, returning the signature or transaction hash.
+
+### Options Parameter
+
+The `signRequest` method accepts an optional second parameter `options`:
+
+- **`address`**: If specified, SafeSigner will enforce that the user connects with this exact wallet address before allowing them to sign.
+
+```typescript
+const { data: signedMessage, error } = await signer.signRequest(request, {
+    address: '0x1234567890123456789012345678901234567890'
+});
+```
 
 ### API Use
 
 You can also interact with SafeSigner through an API:
 ```bash
     npx tsx ./start.ts # This starts the server so that requests can be received
+    
+    # Basic request
     curl -X POST \
         -H 'Content-Type: application/json' \
-        -d '{"message": "Hello, world!"}' \
+        -d '{"request": {"message": "Hello, world!"}}' \
         http://localhost:3000/api/submit-request
 
+    # Request with address enforcement
+    curl -X POST \
+        -H 'Content-Type: application/json' \
+        -d '{"request": {"message": "Hello, world!"}, "options": {"address": "0x1234567890123456789012345678901234567890"}}' \
+        http://localhost:3000/api/submit-request
 ```
 
 ## Running the Example

--- a/example.ts
+++ b/example.ts
@@ -63,8 +63,8 @@ async function main() {
   await signer.start();
   console.log("SafeSigner started");
   try {
-    console.log("Asking for signature on message");
-    const messageResponse = await signer.sendRequest(messageRequest);
+    console.log("Asking for signature on message from specific address");
+    const messageResponse = await signer.sendRequest(messageRequest, { address: '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' });
     console.log('Message signature:', messageResponse);
 
     console.log("Asking for signature on EIP712 Typed Data Message");

--- a/src/components/AddressModal.tsx
+++ b/src/components/AddressModal.tsx
@@ -1,0 +1,90 @@
+interface AddressModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  requiredAddress: string;
+}
+
+function AddressModal({ isOpen, onClose, requiredAddress }: AddressModalProps) {
+  const handleClose = () => {
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      zIndex: 50,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center'
+    }}>
+      {/* Backdrop */}
+      <div 
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          backgroundColor: 'rgba(0, 0, 0, 0.5)'
+        }}
+        onClick={handleClose}
+      />
+      
+      {/* Modal */}
+      <div style={{
+        position: 'relative',
+        backgroundColor: 'white',
+        borderRadius: '8px',
+        boxShadow: '0 20px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.04)',
+        maxWidth: '28rem',
+        width: '100%',
+        margin: '0 1rem'
+      }}>
+        <div style={{ padding: '1.5rem' }}>
+          <h2 style={{ fontSize: '1.25rem', fontWeight: 'bold', color: '#111827', marginBottom: '1rem' }}>
+            Wrong Address Connected
+          </h2>
+          <p style={{ color: '#4B5563', marginBottom: '1rem' }}>
+            You must connect with a specific address to continue.
+          </p>
+          <p style={{ fontSize: '0.875rem', color: '#6B7280', marginBottom: '1rem' }}>
+            Required address: <span style={{ fontFamily: 'monospace', fontWeight: 'bold', color: '#111827' }}>{requiredAddress}</span>
+          </p>
+          <p style={{ color: '#4B5563', marginBottom: '1rem' }}>
+            Make sure you've switched to this address in your wallet before trying again.
+          </p>
+          <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <button 
+              onClick={handleClose}
+              style={{
+                backgroundColor: '#2563EB',
+                color: 'white',
+                fontWeight: '500',
+                padding: '0.5rem 1rem',
+                borderRadius: '6px',
+                border: 'none',
+                cursor: 'pointer'
+              }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.backgroundColor = '#1D4ED8';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.backgroundColor = '#2563EB';
+              }}
+            >
+              Try Again
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AddressModal;

--- a/src/components/RequireAddress.tsx
+++ b/src/components/RequireAddress.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { useAccount, useDisconnect } from 'wagmi';
+import { useConnectModal } from '@rainbow-me/rainbowkit';
+import { useContext } from 'react';
+import { SocketIOContext } from './SocketIOContext';
+import AddressModal from './AddressModal';
+
+export function RequireAddress() {
+  const { address, isConnected } = useAccount();
+  const { disconnect } = useDisconnect();
+  const { openConnectModal } = useConnectModal();
+  const { options } = useContext(SocketIOContext);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [hasDisconnected, setHasDisconnected] = useState(false);
+
+  const requiredAddress = options?.address?.toLowerCase();
+
+  useEffect(() => {
+    if (!hasDisconnected && openConnectModal) {
+      disconnect();
+      setHasDisconnected(true);
+      openConnectModal();
+    }
+  }, [hasDisconnected, openConnectModal, disconnect]);
+
+  useEffect(() => {
+    if (!isConnected || !address || !requiredAddress) return;
+
+    const currentAddress = address.toLowerCase();
+    
+    if (currentAddress !== requiredAddress) {
+      setIsModalOpen(true);
+      disconnect();
+    }
+  }, [isConnected, address, requiredAddress, disconnect]);
+
+  return (
+    <AddressModal 
+      isOpen={isModalOpen} 
+      requiredAddress={requiredAddress || ''}
+      onClose={() => {
+        setIsModalOpen(false);
+        openConnectModal?.();
+      }} 
+    />
+  );
+} 

--- a/src/components/SocketIOContext.tsx
+++ b/src/components/SocketIOContext.tsx
@@ -6,7 +6,7 @@ import React, {
   createContext,
 } from "react";
 import io, { Socket } from "socket.io-client";
-import { SafeSignerRequest } from "..";
+import { SafeSignerOptions, SafeSignerRequest } from "..";
 import { DefaultEventsMap } from "socket.io/dist/typed-events";
 
 export type SocketIOEmitter = (<Ev extends string>(
@@ -16,6 +16,7 @@ export type SocketIOEmitter = (<Ev extends string>(
 
 const defaultContext = {
   request: null as SafeSignerRequest | null,
+  options: null as SafeSignerOptions | null,
   emit: undefined as SocketIOEmitter | undefined,
 };
 
@@ -27,6 +28,7 @@ export const SocketIOProvider = ({
   children: ReactNode;
 }): React.JSX.Element => {
   const [request, setRequest] = useState<SafeSignerRequest | null>(null);
+  const [options, setOptions] = useState<SafeSignerOptions | null>(null);
   const socketRef = useRef<Socket | null>(null);
 
   useEffect(() => {
@@ -38,9 +40,10 @@ export const SocketIOProvider = ({
         socketRef.current?.emit("ready");
       });
 
-      socketRef.current.on("request", (newRequest) => {
+      socketRef.current.on("request", (newRequest, options) => {
         setRequest(newRequest);
-        console.log("Received request", newRequest);
+        setOptions(options);
+        console.log("Received request", newRequest, options);
       });
 
       socketRef.current.on("disconnect", () => {
@@ -57,6 +60,7 @@ export const SocketIOProvider = ({
 
   const ret = {
     request,
+    options,
     emit: socketRef.current?.emit.bind(socketRef.current),
   };
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,20 +1,21 @@
-import { useConnectModal, ConnectButton } from "@rainbow-me/rainbowkit";
 import type { NextPage } from "next";
 import Head from "next/head";
 import styles from "../styles/Home.module.css";
-import { useWalletClient } from "wagmi";
-import { useEffect } from "react";
+import { useWalletClient, useAccount } from "wagmi";
+import { useContext } from "react";
 import Signer from "../components/Signer";
+import { SocketIOContext } from "../components/SocketIOContext";
+import { RequireAddress } from "../components/RequireAddress";
+import { ConnectButton } from "@rainbow-me/rainbowkit";
 
 const Home: NextPage = () => {
   const { data: walletClient } = useWalletClient();
-  const { openConnectModal } = useConnectModal();
-  useEffect(() => {
-    if (walletClient) {
-    } else if (openConnectModal) {
-      openConnectModal();
-    }
-  }, [walletClient, openConnectModal]);
+  const { address, addresses } = useAccount();
+  const { options } = useContext(SocketIOContext);
+
+  const specificAddressRequired = !!options && options.address;
+  const isCorrectAddress = address?.toLowerCase() === options?.address?.toLowerCase();
+  const shouldShowSigner = !!walletClient && (!specificAddressRequired || isCorrectAddress);
 
   return (
     <div className={styles.container}>
@@ -26,8 +27,20 @@ const Home: NextPage = () => {
         />
         <link href="/favicon.ico" rel="icon" />
       </Head>
-      <ConnectButton />
-      {walletClient && <Signer />}
+      
+      <div style={{
+        position: 'absolute',
+        top: '1rem',
+        right: '1rem',
+        zIndex: 10
+      }}>
+        <ConnectButton />
+      </div>
+      
+      <h1>SafeSigner</h1>
+      <p>Connect your wallet to sign transactions and messages</p>
+      {specificAddressRequired && <RequireAddress />}
+      {shouldShowSigner && <Signer />}
     </div>
   );
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,7 +3,7 @@ import http from 'http';
 import { Server as SocketIOServer } from 'socket.io';
 import next from 'next';
 import path from 'path'
-import { SafeSignerRequest } from '.';
+import { SafeSignerRequest, SafeSignerOptions } from '.';
 import { RequestHandler } from 'next/dist/server/next';
 
 const dev = process.env.NODE_ENV !== 'production';
@@ -31,8 +31,8 @@ export async function startServer(port: number = 3000): Promise<{ server: http.S
       io.emit('response', response);
     });
 
-    socket.on('request', (request: SafeSignerRequest) => {
-      io.emit('request', request);
+    socket.on('request', (request: SafeSignerRequest, options: SafeSignerOptions = {}) => {
+      io.emit('request', request, options);
     });
 
     socket.on('disconnect', () => {


### PR DESCRIPTION
### Why
The current flow immediately requests the user's signature, without giving them time to choose which address they want to sign with, just defaulting to the first connected account.

### How
- Adds a second `options` parameter to the `sendRequest()` function where users can specify an address that should do the signing. 
- Updates the front end to require the user to connect with that address before signing the message or tx.

[Screencast from 2025-08-28 19-40-36.webm](https://github.com/user-attachments/assets/429d903d-92ce-40c6-85b5-a4d0433ea864)
